### PR TITLE
Hacktoberfest - Cleanup "slave" references in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,15 +183,15 @@ Exit status above 128 indicates that a signal terminated the job.  See
 
 Each project has a *Workspace* button that you can use to view the
 project workspace files in your web browser.  This handy feature relies
-on the slave that executed the job.  SGE slaves are reused and if kept
-busy they can live a long and productive life.  However, slaves left
-idle for an extended time are deleted.  Once the slave is gone, the
+on the agent that executed the job.  SGE agents are reused and if kept
+busy they can live a long and productive life.  However, agents left
+idle for an extended time are deleted.  Once the agent is gone, the
 *Workspace* button will no longer work.  Then the files can only be
 viewed using other methods like the command line.
 
 In J*enkins \> Manage Jenkins \> Configure System \> SGE Cloud*, the
-*Maximum idle time* field controls how long idle slaves are retained.
- If you find that slaves disappear while you still want to view the
+*Maximum idle time* field controls how long idle agents are retained.
+ If you find that agents disappear while you still want to view the
 workspace, increase *Maximum idle time*.
 
 ## Environment Variables

--- a/developer_documentation.md
+++ b/developer_documentation.md
@@ -65,11 +65,11 @@ This is an abstract class, all of its methods are abstract, and it represents al
 ### SGE.java
 This class extends the `BatchSystem` class and implements all of its methods. The `BatchSystem` methods are implemented using the actions and commands specific to `SGE` batch system. The interaction with `SGE` is realized through execution of shell commands and extraction of needed information from the output of the commands.
 ### SGESlave.java
-This class represents the slave created by the cloud when a job with the appropriate label is run. It extends the `Slave` class which has most of its functionality. There is not much in the extended class.  The most important part of this extended class is the constructor which chooses the connection to the slave method (`SSHLauncher`), and the retention strategy (`SGERetentionStrategy`), it also sets the label which specifies which jobs the slave will be able to execute.
+This class represents the agent created by the cloud when a job with the appropriate label is run. It extends the `Slave` class which has most of its functionality. There is not much in the extended class.  The most important part of this extended class is the constructor which chooses the connection method (`SSHLauncher`), and the retention strategy (`SGERetentionStrategy`), it also sets the label which specifies which jobs the agent will be able to execute.
 ### SGERetentionStrategy.java
-This class determines when an idle slave (a slave who isn't doing any job) should be terminated (disconnected). It also takes care of terminating offline slaves. So it is a class which checks all slave computer status and determines if they should be terminated.
+This class determines when an idle agent (an agent that isn't doing any job) should be terminated (disconnected). It also takes care of terminating offline agents. So it is a class which checks all agent computer statuses and determines if they should be terminated.
 ### SGECloud.java
-This class checks job labels and determines if a slave should be created. If the label matches the cloud's label the cloud creates a new slave and initiates its connection to the computer through SSH by giving it the credentials which are provided by the user when creating the cloud.
+This class checks job labels and determines if an agent should be created. If the label matches the cloud's label the cloud creates a new agent and initiates its connection to the computer through SSH by giving it the credentials which are provided by the user when creating the cloud.
 
 The configuration section interface for this cloud is generated from `SGECloud/config.jelly`.
 ### SGEBuilder.java

--- a/src/main/resources/org/jenkinsci/plugins/sge/BatchCloud/help-maximumIdleMinutes.html
+++ b/src/main/resources/org/jenkinsci/plugins/sge/BatchCloud/help-maximumIdleMinutes.html
@@ -1,20 +1,20 @@
 <div>
   <p>
   When it starts a new job, Jenkins SGE Plugin tries to use an existing idle
-  slave.  If there are no idle slaves, a new slave is automatically
+  agent.  If there are no idle agents, a new agent is automatically
   provisioned.</p>
   <p>
-  When things are less busy, idle slaves are terminated after being idle for the
+  When things are less busy, idle agents are terminated after being idle for the
   <em>Maximum idle time</em> specified here.</p>
   <p>
   Each project has a <em>Workspace</em> button that you can use to view the
   project workspace files in your web browser.  This handy feature relies on the
-  slave that executed the job.  If the slave is gone, the workspace can no
+  agent that executed the job.  If the agent is gone, the workspace can no
   longer be viewed via the Jenkins web interface.  If this happens often,
   consider increasing the <em>Maximum idle time</em>.</p>
   <p>
   Note that the <em>Maximum idle time</em> applies only to newly provisioned
-  slaves.  Existing slaves retain the maximum idle time that was in effect when
+  agents.  Existing agents retain the maximum idle time that was in effect when
   they were provisioned.</p>
   <p>
   Handy conversions:

--- a/src/main/resources/org/jenkinsci/plugins/sge/BatchCloud/help-username.html
+++ b/src/main/resources/org/jenkinsci/plugins/sge/BatchCloud/help-username.html
@@ -1,3 +1,3 @@
 <div>
-  The name of the user that will connect to the slave(s) via SSH.
+  The name of the user that will connect to the agent(s) via SSH.
 </div>


### PR DESCRIPTION
Cleans up the "Jenkins slave" term from user-facing documentation and built-in help pages. The code still needs to be updated.